### PR TITLE
fix: set proxy_http_version to 1.1

### DIFF
--- a/letsencrypt-reverse-proxy/docker/config/proxy.conf
+++ b/letsencrypt-reverse-proxy/docker/config/proxy.conf
@@ -1,4 +1,5 @@
 proxy_redirect          off;
+proxy_http_version      1.1;
 proxy_set_header        Host            $host;
 proxy_set_header        X-Real-IP       $remote_addr;
 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This fix is needed such that the reverse proxy works correctly with Jupyter Notebook.
See https://stackoverflow.com/questions/48014819/jupyter-notebook-keeps-reconnecting